### PR TITLE
Update account sequence only after successful tx

### DIFF
--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -322,18 +322,18 @@ impl BaseClient {
             mode: 2, // BROADCAST_MODE_SYNC -> Wait for the tx to be processed, but not in-block
         };
         let resp = self.tx_client.broadcast_tx(request).await?;
-        self.account_sequence = Some(sequence + 1);
-
         let resp = resp.into_inner();
         log::debug!("broadcast_tx response: {:#?}", resp);
         let tx_response = resp.tx_response.ok_or("Tx response not found")?;
         if tx_response.code != 0 {
             return Err(Error::Unknown(format!(
                 "Transaction failed with code: {} ({})",
-                tx_response.code,
-                tx_response.raw_log
+                tx_response.code, tx_response.raw_log
             )));
         }
+
+        // Bump up the local account sequence after successful tx.
+        self.account_sequence = Some(sequence + 1);
         let hash = tx_response.txhash;
         Ok(hash)
     }


### PR DESCRIPTION
The original code here updated account sequence every time a transaction was successfully broadcasted, but despite of successful broadcast, the transaction could still fail, which would lead to situation where on-chain account sequence stays unchanged, but local book keeping gets one step ahead, basically leading to situation where the client instance is permanently unable to transmit any further transactions, unless some external event triggered on-chain account sequence change.

This change moves the local book keeping update to point where we know that the transaction successfully executed.