### PR TITLE
runtime-config: add debug exit definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +751,7 @@ version = "0.1.0"
 dependencies = [
  "backon",
  "bip32",
+ "const_format",
  "cosmos-sdk-proto",
  "cosmrs",
  "derivative",
@@ -743,6 +764,7 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_core",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2565,6 +2587,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "gevulot_rs"
 path = "src/lib.rs"
 
 [dependencies]
+const_format = "0.2.33"
 cosmos-sdk-proto = "0.25"
 cosmrs = { version = "0.20", features = ["tokio", "grpc", "rpc", "tendermint-rpc"] }
 bip32 =  { version = "0.5.1", features = [ "mnemonic", "bip39" ] }
@@ -20,6 +21,7 @@ pretty_env_logger = "0.5.0"
 prost = "0.13"
 rand = "0.8.5"
 rand_core = "0.6.4"
+semver = "1"
 serde = "1"
 serde_json = "1"
 tendermint = "0.39.1"

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -41,7 +41,7 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 
 /// Version of runtime configuration.
-pub const VERSION: &str = "1";
+pub const VERSION: &str = "1.1";
 
 /// Environment variable definition.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 pub const VERSION: &str = "1";
 
 /// Environment variable definition.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct EnvVar {
     pub key: String,
     pub value: String,
@@ -187,7 +187,7 @@ pub struct RuntimeConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{DebugExit, RuntimeConfig};
+    use super::{DebugExit, EnvVar, RuntimeConfig};
 
     #[test]
     fn test_deserialize_version_ok() {
@@ -259,8 +259,13 @@ mod tests {
         );
         assert_eq!(result.args, vec!["--log".to_string(), "info".to_string()]);
         assert_eq!(result.env.len(), 1);
-        assert_eq!(result.env[0].key, "TMPDIR".to_string());
-        assert_eq!(result.env[0].value, "/tmp".to_string());
+        assert_eq!(
+            result.env[0],
+            EnvVar {
+                key: "TMPDIR".to_string(),
+                value: "/tmp".to_string()
+            }
+        );
         assert_eq!(
             &result.working_dir.expect("working dir should be present"),
             "/"


### PR DESCRIPTION
## DebugExit

This PR adds `DebugExit` definition to runtime configuration. `DebugExit` describes how VM will report main application status to the outside world depending on architecture.

In future this may potentially be expanded to e.g. `result-file` meta-architecture, which will utilize file-based approach to report status.

R.n. only `x86` implemented, which uses `isa-debug-exit` QEMU device:

```shell
qemu-system-x86_64 -device isa-debug-exit,iobase=0xf4,iosize=0x04 ...
```

Although the options for port&size are available, there is no need to use anything except `DebugExit::default_x86()` for now.

## SemVer

Also this PR brings semantic versioning to runtime configuration. This will allow  for example to use this crate with `1.1` version of runtime config with config files of version `1`.

Version strings are going to be completed up to SemVer format `X.Y.Z` after deserialization before comparison. So you can write `version: 1` in the config file and it will be expanded to `1.0.0` before checking compatibility. Everything else is handled by `semver` crate.