### PR TITLE
upgrade the pin protobufs, so that CID is optional

### DIFF
--- a/proto/gevulot/gevulot/pin.proto
+++ b/proto/gevulot/gevulot/pin.proto
@@ -21,9 +21,11 @@ message PinSpec {
 message PinStatus {
   repeated string assignedWorkers = 1;
   repeated PinAck workerAcks = 2;
+  string cid = 3;
 }
 
 message PinAck {
   string worker = 1;
   uint64 blockHeight = 2;
+  bool success = 3;
 }

--- a/proto/gevulot/gevulot/tx.proto
+++ b/proto/gevulot/gevulot/tx.proto
@@ -238,12 +238,15 @@ message MsgCreatePin {
   repeated string              fallback_urls = 10;
 }
 
-message MsgCreatePinResponse {}
+message MsgCreatePinResponse {
+  string id = 1;
+}
 
 message MsgDeletePin {
   option (cosmos.msg.v1.signer) = "creator";
   string creator = 1;
   string cid     = 2;
+  string id      = 3;
 }
 
 message MsgDeletePinResponse {}
@@ -253,6 +256,8 @@ message MsgAckPin {
   string creator  = 1;
   string workerId = 2;
   string cid      = 3;
+  string id       = 4;
+  bool success    = 5;
 }
 
 message MsgAckPinResponse {}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -185,6 +185,7 @@ impl MsgCreatePinBuilder {
 pub struct MsgDeletePin {
     pub creator: String,
     pub cid: String,
+    pub id: String,
 }
 
 impl MsgDeletePinBuilder {
@@ -195,6 +196,7 @@ impl MsgDeletePinBuilder {
         Ok(gevulot::MsgDeletePin {
             creator: msg.creator,
             cid: msg.cid,
+            id: msg.id,
         })
     }
 }
@@ -253,7 +255,9 @@ impl MsgDeleteWorkerBuilder {
 pub struct MsgAckPin {
     pub creator: String,
     pub cid: String,
+    pub id: String,
     pub worker_id: String,
+    pub success: bool,
 }
 
 impl MsgAckPinBuilder {
@@ -264,7 +268,9 @@ impl MsgAckPinBuilder {
         Ok(gevulot::MsgAckPin {
             creator: msg.creator,
             cid: msg.cid,
+            id: msg.id,
             worker_id: msg.worker_id,
+            success: msg.success,
         })
     }
 }


### PR DESCRIPTION
This prepares the pin protobufs so that we can make the CID optional. It adds the ID field, and also adds a "success" field to the PinAck type that will allow signaling that sara failed to pin a specific file