### PR TITLE
allow empty cid in pin model

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -109,11 +109,10 @@ pub struct Pin {
 impl From<gevulot::Pin> for Pin {
     fn from(proto: gevulot::Pin) -> Self {
         let mut spec: PinSpec = proto.spec.unwrap().into();
-        spec.cid = proto
-            .metadata
+        spec.cid = proto.status
             .as_ref()
-            .map(|m| m.id.clone())
-            .unwrap_or_default();
+            .map(|s| s.cid.clone())
+            .or_else(|| proto.metadata.as_ref().map(|m| m.id.clone()));
         Pin {
             kind: "Pin".to_string(),
             version: "v0".to_string(),
@@ -156,7 +155,7 @@ impl From<gevulot::Pin> for Pin {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PinSpec {
-    pub cid: String,
+    pub cid: Option<String>,
     pub bytes: i64,
     pub time: i64,
     pub redundancy: i64,
@@ -167,7 +166,7 @@ pub struct PinSpec {
 impl From<gevulot::PinSpec> for PinSpec {
     fn from(proto: gevulot::PinSpec) -> Self {
         PinSpec {
-            cid: "".to_string(),
+            cid: None,
             bytes: proto.bytes as i64,
             time: proto.time as i64,
             redundancy: proto.redundancy as i64,
@@ -182,6 +181,7 @@ pub struct PinStatus {
     pub assigned_workers: Vec<String>,
     #[serde(rename = "workerAcks")]
     pub worker_acks: Vec<PinAck>,
+    pub cid: Option<String>,
 }
 
 impl From<gevulot::PinStatus> for PinStatus {
@@ -196,6 +196,7 @@ impl From<gevulot::PinStatus> for PinStatus {
                     block_height: a.block_height as i64,
                 })
                 .collect(),
+            cid: Some(proto.cid)
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -109,7 +109,8 @@ pub struct Pin {
 impl From<gevulot::Pin> for Pin {
     fn from(proto: gevulot::Pin) -> Self {
         let mut spec: PinSpec = proto.spec.unwrap().into();
-        spec.cid = proto.status
+        spec.cid = proto
+            .status
             .as_ref()
             .map(|s| s.cid.clone())
             .or_else(|| proto.metadata.as_ref().map(|m| m.id.clone()));
@@ -196,7 +197,7 @@ impl From<gevulot::PinStatus> for PinStatus {
                     block_height: a.block_height as i64,
                 })
                 .collect(),
-            cid: Some(proto.cid)
+            cid: Some(proto.cid),
         }
     }
 }


### PR DESCRIPTION
When feeding a Pin spec into gvltctl, it currently blows up when no CID is defined. But since we now actually support adding Pins without CID if it has fallback urls, this needs to be changed.