### PR TITLE
Make version pre-prelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.3"
+version = "0.1.3-pre"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.3"
+version = "0.1.3-pre"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"


### PR DESCRIPTION
Publish with pre-release version `0.1.3-pre` just in case something goes wrong. So we won't need to bump the version from `0.1.3`, which is aligned with platform now.
After successful publish we can re-publish release version `0.1.3`.