### PR TITLE
docs.rs-specific build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+
+# Used by pre-publish script for proto-files which must go to Cargo package
+buf_exported/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.3-pre"
+version = "0.1.3-pre.1"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.3-pre"
+version = "0.1.3-pre.1"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,18 @@ readme = "README.md"
 documentation = "https://docs.rs/gevulot-rs"
 license = "MIT OR Apache-2.0"
 rust-version = "1.75"
-exclude = [".github/**", "flake.nix", "flake.lock", ".envrc", "go.mod"]
+include = [
+    "/buf_exported",
+    "/proto",
+    "/src",
+    ".gitignore",
+    "/buf.work.yaml",
+    "/build.rs",
+    "/Cargo.lock",
+    "/Cargo.toml",
+    "/LICENSE*",
+    "/README.md",
+]
 
 [lib]
 name = "gevulot_rs"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 
 - [`buf`](https://buf.build/)
 - [`protoc`](https://protobuf.dev/)
+
+## Publishing to crates.io
+
+```shell
+./scripts/prepare_publish.sh
+cargo publish
+```

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use prost_build::Config;
+use std::io::Read;
 use std::{env::set_current_dir, path::PathBuf};
 
 fn main() {
@@ -7,9 +8,37 @@ fn main() {
     config.enable_type_names();
 
     set_current_dir("./").unwrap();
-    tonic_buf_build::compile_from_buf_workspace(
-        tonic_build::configure().build_client(true).out_dir(out_dir),
-        Some(config),
-    )
-    .unwrap();
+
+    // Since there is no buf on Rust build environment, we manually (locally)
+    // export all proto-files using buf (see ./scripts/prepare_publish.sh),
+    // and add them to the package.
+    // So when building on docs.rs, raw protoc is used.
+    if std::env::var("DOCS_RS").is_ok() {
+        // Read the list of proto files to compile from buf_exported/protos.txt
+        let protos_file = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap())
+            .join("buf_exported")
+            .join("protos.txt");
+        let mut buffer = String::new();
+        std::fs::File::open(&protos_file)
+            .expect("failed to open protos.txt")
+            .read_to_string(&mut buffer)
+            .expect("failed to read protos.txt");
+        let protos = buffer
+            .lines()
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
+
+        let includes = vec!["./proto", "./buf_exported"];
+
+        let tonic_builder = tonic_build::configure().build_client(true).out_dir(out_dir);
+        tonic_builder
+            .compile_with_config(config, &protos, &includes)
+            .unwrap();
+    } else {
+        tonic_buf_build::compile_from_buf_workspace(
+            tonic_build::configure().build_client(true).out_dir(out_dir),
+            Some(config),
+        )
+        .unwrap();
+    }
 }

--- a/scripts/prepare_publish.sh
+++ b/scripts/prepare_publish.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+EXPORT_DIR=buf_exported
+
+mkdir -p ${EXPORT_DIR}
+
+# Export all proto-files
+buf export -o ${EXPORT_DIR}
+
+# List proto files to compile (captured in build.rs)
+buf ls-files > ${EXPORT_DIR}/protos.txt


### PR DESCRIPTION
- Before running `cargo publish`, you should run `./scripts/prepare_publish.sh`.
- When building on `docs.rs` server, `buf` won't be used. Exported files will be compiled directly with `tonic` instead.