### PR TITLE
Add GitHub workflow for publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run pre-publish script
+        run: |
+          ./scripts/prepare_publish.sh
+
+      - name: Check proto files export
+        run: |
+          ls buf_exported/
+          cat buf_exported/protos.txt
+
+      - name: Cargo login
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo login
+
+      - name: Cargo publish
+        # --allow-dirty is required because buf-exportes files are not commited to git,
+        # but included into package
+        run: |
+          cargo publish --allow-dirty
+
+      - name: Cargo logout
+        run: |
+          cargo logout


### PR DESCRIPTION
This workflow publishes to crates.io every time a tag like `v1.2.3` is pushed.

I'm not sure should we automatically publish pre-release versions like `v1.2.3-pre`, so I didn't added them for now.

For this to work we need to set `secrets.CARGO_REGISTRY_TOKEN` first.