### PR TITLE
Bump `gevulot-rs` version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.3-pre.4"
+version = "0.1.3"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.3-pre.4"
+version = "0.1.3"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"


### PR DESCRIPTION
Looks like we are ready to release stable version `0.1.3` for crates.io