### PR TITLE
Tx error handling

### DIFF
--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -331,12 +331,7 @@ impl BaseClient {
         let resp = resp.into_inner();
         log::debug!("broadcast_tx response: {:#?}", resp);
         let tx_response = resp.tx_response.ok_or("Tx response not found")?;
-        if tx_response.code != 0 {
-            return Err(Error::Unknown(format!(
-                "Transaction failed with code: {} ({})",
-                tx_response.code, tx_response.raw_log
-            )));
-        }
+        Self::assert_tx_success(&tx_response)?;
 
         // Bump up the local account sequence after successful tx.
         self.account_sequence = Some(sequence + 1);

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -363,6 +363,10 @@ impl BaseClient {
         self.wait_for_tx(&hash, Some(tokio::time::Duration::from_secs(10)))
             .await?;
         let tx_response: TxResponse = self.get_tx_response(&hash).await?;
+        let (tx_code, raw_log) = (tx_response.code, tx_response.raw_log);
+        if tx_code != 0 {
+            return Err(Error::Tx(tx_code, raw_log));
+        }
         let tx_msg_data = cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxMsgData::decode(
             &*hex::decode(tx_response.data)?,
         )?;

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -380,9 +380,13 @@ impl BaseClient {
     ///
     /// An empty Result or a Tx error.
     fn assert_tx_success(tx_response: &TxResponse) -> Result<()> {
-        let (tx_code, raw_log) = (tx_response.code, tx_response.raw_log.to_owned());
+        let (tx_hash, tx_code, raw_log) = (
+            tx_response.txhash.to_owned(),
+            tx_response.code,
+            tx_response.raw_log.to_owned(),
+        );
         if tx_code != 0 {
-            return Err(Error::Tx(tx_code, raw_log));
+            return Err(Error::Tx(tx_hash, tx_code, raw_log));
         }
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,8 @@ pub enum Error {
     Parse(String),
     #[error("tendermint error: {0}")]
     Tendermint(#[from] tendermint::Error),
-    #[error("tx failed with code {0}: {1}")]
-    Tx(u32, String),
+    #[error("tx {0} failed with code {1}: {2}")]
+    Tx(String, u32, String),
     #[error("unknown error: {0}")]
     Unknown(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     Parse(String),
     #[error("tendermint error: {0}")]
     Tendermint(#[from] tendermint::Error),
+    #[error("tx failed with code {0}: {1}")]
+    Tx(u32, String),
     #[error("unknown error: {0}")]
     Unknown(String),
 }


### PR DESCRIPTION
We have handling for tx failures, after tx is broadcasted with **sync mode**:

https://github.com/gevulotnetwork/gevulot-rs/blob/ad1190dd0320a30988a4777a802526b9353b4cfd/src/base_client.rs#L332-L339

Sync mode means that basic checks are done (structure, signatures, fees), and tx is added to the mempool. However, execution still can fail **later**.

Currently we fetch the tx response and blindly start parsing its message - even if tx code is non-zero - which results in `Error: Unknown("no response message")`.

---

This PR improves handling with a dedicated Tx error: hash, code and log included.

For example, instead of "no response message" (like in https://github.com/gevulotnetwork/gvltctl/issues/44), now you will get:

```
Error: Tx("A3469D4B4A2D046B41752FA8DFA7FA2787881126E3CF1C10AFE6CB3351EACDA7", 11, "out of gas in location: IterNextFlat; gasWanted: 106014, gasUsed: 106022: out of gas")
```
