### PR TITLE
Prepare release 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"


### PR DESCRIPTION
- Bump `gevulot-rs` crate version.