### PR TITLE
Bump version to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"


### PR DESCRIPTION
We've made some API changes and pushed `0.1.4` release, which breaks compatibility.
Right now if you depend on `gevulot-rs 0.1`, you can get get compilation error.

We have to release 0.2 version now and yank 0.1.4.