### PR TITLE
Add SemVer violation check to publishing CI workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,9 @@ jobs:
           ls buf_exported/
           cat buf_exported/protos.txt
 
+      - name: Check SemVer violations
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
       - name: Cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This tool will review the API against the latest version already released on crates.io and try to check if there is a SemVer violation (whether crate version changed properly or not).

# Important note

This tool **has quite a few false negatives** and may not catch all the violations. E.g. adding new item (function, structure) to a public API doesn't trigger minor update.

You should still watch out for SemVer manually. If this step at CI is green **it doesn't mean that everything is fine**.

However I think that it's still better to have it here that not to have it: it may catch at least something and warn you on time.