### PR TITLE
Refine API

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 mod serialization_helpers;
-use serialization_helpers::*;
+pub use serialization_helpers::{
+    ByteUnit, CoreUnit, DefaultFactor, DefaultFactorOne, DefaultFactorOneGigabyte,
+    DefaultFactorOneKilobyte, DefaultFactorOneMegabyte, TimeUnit,
+};
 
 mod metadata;
 pub use metadata::{Label, Metadata};

--- a/src/models/pin.rs
+++ b/src/models/pin.rs
@@ -205,8 +205,8 @@ impl From<gevulot::PinSpec> for PinSpec {
     fn from(proto: gevulot::PinSpec) -> Self {
         PinSpec {
             cid: None,
-            bytes: (proto.bytes as i64).into(),
-            time: (proto.time as i64).into(),
+            bytes: proto.bytes.into(),
+            time: proto.time.into(),
             redundancy: proto.redundancy as i64,
             fallback_urls: Some(proto.fallback_urls),
         }

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -203,10 +203,10 @@ impl From<gevulot::TaskSpec> for TaskSpec {
                 })
                 .collect(),
             resources: TaskResources {
-                cpus: (proto.cpus as i64).into(),
-                gpus: (proto.gpus as i64).into(),
-                memory: (proto.memory as i64).into(),
-                time: (proto.time as i64).into(),
+                cpus: proto.cpus.into(),
+                gpus: proto.gpus.into(),
+                memory: proto.memory.into(),
+                time: proto.time.into(),
             },
             store_stdout: proto.store_stdout,
             store_stderr: proto.store_stderr,

--- a/src/models/worker.rs
+++ b/src/models/worker.rs
@@ -129,10 +129,10 @@ impl From<gevulot::WorkerSpec> for WorkerSpec {
     fn from(proto: gevulot::WorkerSpec) -> Self {
         // Convert protobuf spec to internal spec
         WorkerSpec {
-            cpus: (proto.cpus as i64).into(),
-            gpus: (proto.gpus as i64).into(),
-            memory: (proto.memory as i64).into(),
-            disk: (proto.disk as i64).into(),
+            cpus: proto.cpus.into(),
+            gpus: proto.gpus.into(),
+            memory: proto.memory.into(),
+            disk: proto.disk.into(),
         }
     }
 }
@@ -160,10 +160,10 @@ impl From<gevulot::WorkerStatus> for WorkerStatus {
     fn from(proto: gevulot::WorkerStatus) -> Self {
         // Convert protobuf status to internal status
         WorkerStatus {
-            cpus_used: (proto.cpus_used as i64).into(),
-            gpus_used: (proto.gpus_used as i64).into(),
-            memory_used: (proto.memory_used as i64).into(),
-            disk_used: (proto.disk_used as i64).into(),
+            cpus_used: proto.cpus_used.into(),
+            gpus_used: proto.gpus_used.into(),
+            memory_used: proto.memory_used.into(),
+            disk_used: proto.disk_used.into(),
             exit_announced_at: proto.exit_announced_at as i64,
         }
     }


### PR DESCRIPTION
# Changes

- `ByteUnit`/`CoreUnit`/`TimeUnit` now use `u64` instead of `i64`. It makes no sense to store them as signed, especially because parsing negative units always results in error.
- Serialization helpers are now exposed in public API. This is needed because these types are public fields in different models, which are in public API.
- ~~Re-enabled linting and testing in CI. A bunch of tests were fixed. Old e2e tests were ignored. Clippy warnings fixed.~~
  _UPD. moved to separate PR_

# Notes

Doing all this revealed a number of questions. They are not resolved in this PR, however I will list them here for further discussions.

- Exposing units as public enums makes all of their variants public, which allows to create invalid `{Byte,Core,Time}Unit::String` variants. Probably private implementation pattern should be used here for better API:
  ```rust
  // public type
  pub struct ByteUnit {
      // private inner field
      inner: ByteUnitImpl,
  }
  // private implementation
  enum ByteUnitImpl { ... }
  ```
- Multiplying unit value by factor may overflow and result in a panic. Although it's very unlikely to happened on real input, still probably should be handled.
- There is an inconsistency between `bytesize::ByteSize` and `gevulot_rs::models::ByteUnit`. We use "megabyte" to represent mebibytes, but `bytesize` separates them. Because of that `ByteUnit<DefaultFactorOneMegabyte>::from(1)` and `"1MB".parse::<ByteUnit>()` are not the same.
- `CoreUnit` doesn't implement fractional parse, however it was mentioned in tests. This doesn't work: `"1.5cpus".parse::<CoreUnit>()`. Do we want this?