### PR TITLE
Use build-time environment variables to define chain ID and token denomination

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,9 @@ use prost_build::Config;
 use std::io::Read;
 use std::{env::set_current_dir, path::PathBuf};
 
+const DEFAULT_CHAIN_ID: &str = "gevulot";
+const DEFAULT_TOKEN_DENOM: &str = "ucredit";
+
 fn main() {
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     let mut config = Config::new();
@@ -50,4 +53,12 @@ fn main() {
         )
         .unwrap();
     }
+
+    let chain_id = std::env::var("GEVULOT_CHAIN_ID").unwrap_or(DEFAULT_CHAIN_ID.to_string());
+    println!("cargo:rustc-env=GEVULOT_CHAIN_ID={}", chain_id);
+    println!("cargo:rerun-if-env-changed=GEVULOT_CHAIN_ID");
+
+    let denom = std::env::var("GEVULOT_TOKEN_DENOM").unwrap_or(DEFAULT_TOKEN_DENOM.to_string());
+    println!("cargo:rustc-env=GEVULOT_TOKEN_DENOM={}", denom);
+    println!("cargo:rerun-if-env-changed=GEVULOT_TOKEN_DENOM");
 }

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -91,7 +91,7 @@ impl BaseClient {
             gov_client: GovQueryClient::new(channel.clone()),
             tendermint_client: TendermintClient::new(channel.clone()),
             tx_client: TxServiceClient::new(channel),
-            denom: "ucredit".to_owned(),
+            denom: env!("GEVULOT_TOKEN_DENOM").to_string(),
             gas_price,
             gas_multiplier,
             address: None,
@@ -164,7 +164,7 @@ impl BaseClient {
     pub async fn get_account_balance(&mut self, address: &str) -> Result<Coin> {
         let request = cosmrs::proto::cosmos::bank::v1beta1::QueryBalanceRequest {
             address: address.to_string(),
-            denom: String::from("ucredit"),
+            denom: env!("GEVULOT_TOKEN_DENOM").to_string(),
         };
         let response = self.bank_client.balance(request).await?;
 
@@ -251,7 +251,7 @@ impl BaseClient {
     ) -> Result<SimulateResponse> {
         let msg = cosmrs::Any::from_msg(&msg)?;
         let gas = 100_000u64;
-        let chain_id: cosmrs::tendermint::chain::Id = "gevulot"
+        let chain_id: cosmrs::tendermint::chain::Id = env!("GEVULOT_CHAIN_ID")
             .parse()
             .map_err(|_| Error::Parse("fail".to_string()))?;
         let tx_body = cosmrs::tx::BodyBuilder::new().msg(msg).memo(memo).finish();
@@ -313,7 +313,7 @@ impl BaseClient {
         log::debug!("fee: {:?}", fee);
 
         let msg = cosmrs::Any::from_msg(&msg)?;
-        let chain_id: cosmrs::tendermint::chain::Id = "gevulot"
+        let chain_id: cosmrs::tendermint::chain::Id = env!("GEVULOT_CHAIN_ID")
             .parse()
             .map_err(|_| Error::Parse("fail".to_string()))?;
         let tx_body = cosmrs::tx::BodyBuilder::new().msg(msg).memo(memo).finish();

--- a/src/gov_client.rs
+++ b/src/gov_client.rs
@@ -224,7 +224,7 @@ impl GovClient {
         };
 
         let deposit = vec![Coin {
-            denom: "ucredit".to_string(),
+            denom: env!("GEVULOT_TOKEN_DENOM").to_string(),
             amount: deposit.to_string(),
         }];
         let msg = MsgSubmitProposal {


### PR DESCRIPTION
Chain ID and token denomination are now hard-coded, which makes it impossible to use gevulot-rs for a different network.

With these changed one can use env vars `GEVULOT_CHAIN_ID` and `GEVULOT_TOKEN_DENOM` to control these values.

Example:

```
cd gvltctl
GEVULOT_CHAIN_ID=my_chain GEVULOT_TOKEN_DENOM=my_coin cargo build
./target/debug/gvltctl ...
```