### PR TITLE
Customize chain ID and token denomination in GevulotClient

### DIFF
--- a/src/gevulot_client.rs
+++ b/src/gevulot_client.rs
@@ -29,6 +29,8 @@ pub struct GevulotClient {
 /// Builder for GevulotClient
 pub struct GevulotClientBuilder {
     endpoint: String,
+    chain_id: Option<String>,
+    denom: Option<String>,
     gas_price: f64,
     gas_multiplier: f64,
     mnemonic: Option<String>,
@@ -40,6 +42,8 @@ impl Default for GevulotClientBuilder {
     fn default() -> Self {
         Self {
             endpoint: "http://127.0.0.1:9090".to_string(),
+            chain_id: None,
+            denom: None,
             gas_price: 0.025,
             gas_multiplier: 1.2,
             mnemonic: None,
@@ -57,6 +61,18 @@ impl GevulotClientBuilder {
     /// Sets the endpoint for the GevulotClient
     pub fn endpoint(mut self, endpoint: &str) -> Self {
         self.endpoint = endpoint.to_string();
+        self
+    }
+
+    /// Sets the chain ID for the GevulotClient
+    pub fn chain_id(mut self, chain_id: &str) -> Self {
+        self.chain_id = Some(chain_id.to_string());
+        self
+    }
+
+    /// Sets the token denomination for the GevulotClient
+    pub fn denom(mut self, denom: &str) -> Self {
+        self.denom = Some(denom.to_string());
         self
     }
 
@@ -90,6 +106,16 @@ impl GevulotClientBuilder {
         let base_client = Arc::new(RwLock::new(
             BaseClient::new(&self.endpoint, self.gas_price, self.gas_multiplier).await?,
         ));
+
+        // If chain ID is provided, set it in the BaseClient
+        if let Some(chain_id) = self.chain_id {
+            base_client.write().await.chain_id = chain_id;
+        }
+
+        // If token denomination is provided, set it in the BaseClient
+        if let Some(denom) = self.denom {
+            base_client.write().await.denom = denom;
+        }
 
         // If a mnemonic is provided, set it in the BaseClient
         if let Some(mnemonic) = self.mnemonic {

--- a/src/gov_client.rs
+++ b/src/gov_client.rs
@@ -224,7 +224,7 @@ impl GovClient {
         };
 
         let deposit = vec![Coin {
-            denom: "ucredit".to_string(),
+            denom: self.base_client.read().await.denom.to_string(),
             amount: deposit.to_string(),
         }];
         let msg = MsgSubmitProposal {


### PR DESCRIPTION
This allows to set chain ID and token denomination for a client:

```rust
let client = GevulotClientBuilder::new()
    .chain_id("my_chain")
    .denom("my_token")
    .build()
    .await?;
```

Default values are:

```rust
const DEFAULT_CHAIN_ID: &str = "gevulot";
const DEFAULT_TOKEN_DENOM: &str = "ucredit";
```