### PR TITLE
Make signer module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod event_fetcher;
 pub mod events;
 pub mod gov_client;
 /// This module contains the signer implementation.
-mod signer;
+pub mod signer;
 
 /// This module contains the protocol buffer definitions.
 pub mod proto {


### PR DESCRIPTION
Public method `BaseClient::set_signer` has argument of type `gevulot_rs::signer::GevulotSigner`, but `gevulot_rs::signer` was a private module.