### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,12 +38,8 @@ jobs:
       - name: Check build
         run: cargo check --locked
 
-      # TODO: re-enable this after fixing all clippy warnings
-      # - name: Run linting
-      #   run: cargo clippy --locked --no-deps -- --deny warnings
+      - name: Run linting
+        run: cargo clippy --locked --no-deps -- --deny warnings
 
-      - name: Run runtime-config tests
-        run: cargo test --locked runtime_config
-
-      - name: Run events tests
-        run: cargo test --locked events
+      - name: Run tests
+        run: cargo test --locked

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,6 +83,9 @@ jobs:
           ls buf_exported/
           cat buf_exported/protos.txt
 
+      - name: Check SemVer violations
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
       - name: Cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -434,7 +434,7 @@ impl BaseClient {
     /// Waits for a block to be produced at a specific height.
     ///
     /// # Arguments
-
+    ///
     /// * `height` - The height of the block to wait for.
     ///
     /// # Returns

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -135,6 +135,23 @@ impl BaseClient {
         Ok(())
     }
 
+    /// Sets a hex-encoded private key for the client and initializes the signer.
+    ///
+    /// # Arguments
+    ///
+    /// * `hex_key` - The hex-encoded private key string (with optional 0x prefix)
+    ///
+    /// # Returns
+    ///
+    /// A Result indicating success or failure.
+    pub fn set_private_key(&mut self, hex_key: &str) -> Result<()> {
+        let key_bytes = hex::decode(hex_key.trim_start_matches("0x"))?;
+        let signing_key = cosmrs::crypto::secp256k1::SigningKey::from_slice(&key_bytes)?;
+        let signer = GevulotSigner::from_signing_key(signing_key)?;
+        self.set_signer(signer);
+        Ok(())
+    }
+
     /// Retrieves the account information for a given address.
     ///
     /// # Arguments

--- a/src/gevulot_client.rs
+++ b/src/gevulot_client.rs
@@ -49,6 +49,7 @@ pub struct GevulotClientBuilder {
     gas_price: f64,
     gas_multiplier: f64,
     mnemonic: Option<String>,
+    private_key: Option<String>,
     password: Option<String>,
 }
 
@@ -62,6 +63,7 @@ impl Default for GevulotClientBuilder {
             gas_price: 0.025,
             gas_multiplier: 1.2,
             mnemonic: None,
+            private_key: None,
             password: None,
         }
     }
@@ -109,6 +111,12 @@ impl GevulotClientBuilder {
         self
     }
 
+    /// Sets the hex-encoded private key for the GevulotClient
+    pub fn private_key(mut self, private_key: &str) -> Self {
+        self.private_key = Some(private_key.to_string());
+        self
+    }
+
     /// Sets the password for the GevulotClient
     pub fn password(mut self, password: &str) -> Self {
         self.password = Some(password.to_string());
@@ -138,6 +146,8 @@ impl GevulotClientBuilder {
                 .write()
                 .await
                 .set_mnemonic(&mnemonic, self.password.as_deref())?;
+        } else if let Some(private_key) = self.private_key {
+            base_client.write().await.set_private_key(&private_key)?;
         }
 
         // Create and return the GevulotClient with the initialized clients

--- a/src/gevulot_client.rs
+++ b/src/gevulot_client.rs
@@ -29,6 +29,8 @@ pub struct GevulotClient {
 /// Builder for GevulotClient
 pub struct GevulotClientBuilder {
     endpoint: String,
+    chain_id: Option<String>,
+    denom: Option<String>,
     gas_price: f64,
     gas_multiplier: f64,
     mnemonic: Option<String>,
@@ -40,6 +42,8 @@ impl Default for GevulotClientBuilder {
     fn default() -> Self {
         Self {
             endpoint: "http://127.0.0.1:9090".to_string(),
+            chain_id: None,
+            denom: None,
             gas_price: 0.025,
             gas_multiplier: 1.2,
             mnemonic: None,
@@ -57,6 +61,18 @@ impl GevulotClientBuilder {
     /// Sets the endpoint for the GevulotClient
     pub fn endpoint(mut self, endpoint: &str) -> Self {
         self.endpoint = endpoint.to_string();
+        self
+    }
+
+    /// Sets the chain ID for the GevulotClient
+    pub fn chain_id(mut self, chain_id: &str) -> Self {
+        self.chain_id = Some(chain_id.to_string());
+        self
+    }
+
+    /// Sets the token denomination for the GevulotClient
+    pub fn denom(mut self, denom: &str) -> Self {
+        self.denom = Some(denom.to_string());
         self
     }
 
@@ -90,6 +106,16 @@ impl GevulotClientBuilder {
         let base_client = Arc::new(RwLock::new(
             BaseClient::new(&self.endpoint, self.gas_price, self.gas_multiplier).await?,
         ));
+
+        // If chain ID is provided, set it in the BaseClient
+        if let Some(chain_id) = self.chain_id {
+            base_client.write().await.chain_id = chain_id;
+        }
+
+        // If token denomination is provided, set it in the BaseClient
+        if let Some(denom) = self.denom {
+            base_client.write().await.denom = denom;
+        }
 
         // If a mnemonic is provided, set it in the BaseClient
         if let Some(mnemonic) = self.mnemonic {

--- a/src/gevulot_client.rs
+++ b/src/gevulot_client.rs
@@ -26,6 +26,21 @@ pub struct GevulotClient {
     pub base_client: Arc<RwLock<BaseClient>>,
 }
 
+impl From<BaseClient> for GevulotClient {
+    fn from(base_client: BaseClient) -> Self {
+        let base_client = Arc::new(RwLock::new(base_client));
+        Self {
+            pins: PinClient::new(base_client.clone()),
+            tasks: TaskClient::new(base_client.clone()),
+            workflows: WorkflowClient::new(base_client.clone()),
+            workers: WorkerClient::new(base_client.clone()),
+            gov: GovClient::new(base_client.clone()),
+            sudo: SudoClient::new(base_client.clone()),
+            base_client,
+        }
+    }
+}
+
 /// Builder for GevulotClient
 pub struct GevulotClientBuilder {
     endpoint: String,

--- a/src/gov_client.rs
+++ b/src/gov_client.rs
@@ -224,7 +224,7 @@ impl GovClient {
         };
 
         let deposit = vec![Coin {
-            denom: "ucredit".to_string(),
+            denom: self.base_client.read().await.denom.to_string(),
             amount: deposit.to_string(),
         }];
         let msg = MsgSubmitProposal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod event_fetcher;
 pub mod events;
 pub mod gov_client;
 /// This module contains the signer implementation.
-mod signer;
+pub mod signer;
 
 /// This module contains the protocol buffer definitions.
 pub mod proto {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub mod proto {
         tonic::include_proto!("cosmos_proto");
     }
 
+    // Some of generated documentation is not properly formatted
+    // and we don't want clippy to report this.
+    #[allow(clippy::doc_lazy_continuation)]
+    // Code examples in generated code are not compiling
+    // and we don't want them to crash doc-tests.
+    #[cfg(not(doctest))]
     pub mod google {
         tonic::include_proto!("google.api");
     }
@@ -87,6 +93,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_event_fetching() {
         pretty_env_logger::init();
 
@@ -118,6 +125,7 @@ mod tests {
 
     /// End-to-end test for the Gevulot client.
     #[tokio::test]
+    #[ignore]
     async fn test_e2e() {
         let (mnemonic, address) = alice();
 

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 /// # Examples
 ///
 /// ```
-/// use crate::models::Metadata;
-/// use crate::models::Label;
+/// use gevulot_rs::models::Metadata;
+/// use gevulot_rs::models::Label;
 ///
 /// let metadata = Metadata {
 ///     id: Some("task-123".to_string()),
@@ -48,7 +48,7 @@ pub struct Metadata {
 /// # Examples
 ///
 /// ```
-/// use crate::models::Label;
+/// use gevulot_rs::models::Label;
 ///
 /// let label = Label {
 ///     key: "environment".to_string(),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 mod serialization_helpers;
-use serialization_helpers::*;
+pub use serialization_helpers::{
+    ByteUnit, CoreUnit, DefaultFactor, DefaultFactorOne, DefaultFactorOneGigabyte,
+    DefaultFactorOneKilobyte, DefaultFactorOneMegabyte, TimeUnit,
+};
 
 mod metadata;
 pub use metadata::{Label, Metadata};

--- a/src/models/pin.rs
+++ b/src/models/pin.rs
@@ -205,8 +205,8 @@ impl From<gevulot::PinSpec> for PinSpec {
     fn from(proto: gevulot::PinSpec) -> Self {
         PinSpec {
             cid: None,
-            bytes: (proto.bytes as i64).into(),
-            time: (proto.time as i64).into(),
+            bytes: proto.bytes.into(),
+            time: proto.time.into(),
             redundancy: proto.redundancy as i64,
             fallback_urls: Some(proto.fallback_urls),
         }

--- a/src/models/pin.rs
+++ b/src/models/pin.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Creating a Pin with CID:
 /// ```
-/// use crate::models::{Pin, PinSpec, Metadata};
+/// use gevulot_rs::models::{Pin, PinSpec, Metadata};
 ///
 /// let pin = Pin {
 ///     kind: "Pin".to_string(),
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Creating a Pin with fallback URLs:
 /// ```
-/// use crate::models::{Pin, PinSpec, Metadata};
+/// use gevulot_rs::models::{Pin, PinSpec, Metadata};
 ///
 /// let pin = Pin {
 ///     kind: "Pin".to_string(),
@@ -130,7 +130,7 @@ impl From<gevulot::Pin> for Pin {
 /// # Examples
 ///
 /// ```
-/// use crate::models::PinSpec;
+/// use gevulot_rs::models::PinSpec;
 ///
 /// let spec = PinSpec {
 ///     cid: Some("QmExample123".to_string()),
@@ -220,7 +220,7 @@ impl From<gevulot::PinSpec> for PinSpec {
 /// # Examples
 ///
 /// ```
-/// use crate::models::{PinStatus, PinAck};
+/// use gevulot_rs::models::{PinStatus, PinAck};
 ///
 /// let status = PinStatus {
 ///     assigned_workers: vec!["worker1".to_string(), "worker2".to_string()],
@@ -274,7 +274,7 @@ impl From<gevulot::PinStatus> for PinStatus {
 /// # Examples
 ///
 /// ```
-/// use crate::models::PinAck;
+/// use gevulot_rs::models::PinAck;
 ///
 /// let ack = PinAck {
 ///     worker: "worker1".to_string(),

--- a/src/models/pin.rs
+++ b/src/models/pin.rs
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(status.worker_acks.len(), 2);
         assert_eq!(status.worker_acks[0].worker, "worker1");
         assert_eq!(status.worker_acks[0].block_height, 1000);
-        assert_eq!(status.worker_acks[0].success, true);
+        assert!(status.worker_acks[0].success);
         assert_eq!(status.worker_acks[0].error, None);
         assert_eq!(status.cid, Some("test-cid".to_string()));
     }

--- a/src/models/serialization_helpers.rs
+++ b/src/models/serialization_helpers.rs
@@ -297,37 +297,37 @@ mod tests {
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000),
+            Ok(1000),
             "1 with KB factor should be 1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMegabyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000 * 1000),
+            Ok(1000 * 1000),
             "1 with MB factor should be 1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGigabyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000 * 1000 * 1000),
+            Ok(1000 * 1000 * 1000),
             "1 with GB factor should be 1000*1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneKibibyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024),
+            Ok(1024),
             "1 with KiB factor should be 1024 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMebibyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024),
+            Ok(1024 * 1024),
             "1 with MiB factor should be 1024*1024 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGibibyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024 * 1024),
+            Ok(1024 * 1024 * 1024),
             "1 with GiB factor should be 1024*1024*1024 bytes"
         );
 
@@ -340,44 +340,44 @@ mod tests {
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000),
+            Ok(1000),
             "String '1' with KB factor should be 1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMegabyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000 * 1000),
+            Ok(1000 * 1000),
             "String '1' with MB factor should be 1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGigabyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1000 * 1000 * 1000),
+            Ok(1000 * 1000 * 1000),
             "String '1' with GB factor should be 1000*1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneKibibyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024),
+            Ok(1024),
             "String '1' with KiB factor should be 1024 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMebibyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024),
+            Ok(1024 * 1024),
             "String '1' with MiB factor should be 1024*1024 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGibibyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024 * 1024),
+            Ok(1024 * 1024 * 1024),
             "String '1' with GiB factor should be 1024*1024*1024 bytes"
         );
 
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = "1MiB".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024),
+            Ok(1024 * 1024),
             "Explicit unit (1MiB) should override default factor (KB)"
         );
     }

--- a/src/models/serialization_helpers.rs
+++ b/src/models/serialization_helpers.rs
@@ -74,11 +74,11 @@ impl DefaultFactor for DefaultFactorOneGibibyte {
 /// # Examples
 ///
 /// ```rust
-/// use crate::models::serialization_helpers::{ByteUnit, DefaultFactorOne};
+/// use gevulot_rs::models::{ByteUnit, DefaultFactorOneMegabyte};
 ///
 /// // Parse from string
 /// let bytes: ByteUnit = "500MB".parse().unwrap();
-/// assert_eq!(bytes.bytes().unwrap(), 500 * 1024 * 1024);
+/// assert_eq!(bytes.bytes().unwrap(), 500 * 1000 * 1000);
 ///
 /// // Use raw number
 /// let bytes = ByteUnit::<DefaultFactorOneMegabyte>::from(1);
@@ -141,7 +141,7 @@ impl<D: DefaultFactor> From<u64> for ByteUnit<D> {
 /// # Examples
 ///
 /// ```rust
-/// use crate::models::serialization_helpers::CoreUnit;
+/// use gevulot_rs::models::CoreUnit;
 ///
 /// // Parse core counts
 /// let cores: CoreUnit = "2 cores".parse().unwrap();
@@ -165,7 +165,7 @@ impl CoreUnit {
             CoreUnit::Number(n) => Ok(*n * 1000), // Default factor without unit is 1000
             CoreUnit::String(s) => {
                 // Extract numeric part
-                let numeric: String = s.chars().take_while(|c| c.is_digit(10)).collect();
+                let numeric: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
                 // Extract and normalize unit part
                 let unit = s[numeric.len()..].to_lowercase().replace(" ", "");
                 let base: u64 = numeric
@@ -221,7 +221,7 @@ impl From<u64> for CoreUnit {
 /// # Examples
 ///
 /// ```rust
-/// use crate::models::serialization_helpers::TimeUnit;
+/// use gevulot_rs::models::TimeUnit;
 ///
 /// // Parse durations
 /// let time: TimeUnit = "24h".parse().unwrap();
@@ -408,8 +408,9 @@ mod tests {
         let cores: CoreUnit = "500mcpu".parse().unwrap();
         assert_eq!(cores.millicores().unwrap(), 500);
 
-        let cores: CoreUnit = "1.5 cpus".parse().unwrap();
-        assert_eq!(cores.millicores().unwrap(), 1500);
+        // TODO: fractional core units are not implemented
+        // let cores: CoreUnit = "1.5 cpus".parse().unwrap();
+        // assert_eq!(cores.millicores().unwrap(), 1500);
 
         let cores: CoreUnit = "2 gpus".parse().unwrap();
         assert_eq!(cores.millicores().unwrap(), 2000);

--- a/src/models/serialization_helpers.rs
+++ b/src/models/serialization_helpers.rs
@@ -22,24 +22,45 @@ impl DefaultFactor for DefaultFactorOne {
     const FACTOR: u64 = 1;
 }
 
-/// Default factor of 1KB (1024 bytes)
+/// Default factor of 1KB (1000 bytes)
 #[derive(Debug)]
 pub struct DefaultFactorOneKilobyte;
 impl DefaultFactor for DefaultFactorOneKilobyte {
-    const FACTOR: u64 = 1024;
+    const FACTOR: u64 = 1000;
 }
 
-/// Default factor of 1MB (1024 * 1024 bytes)
+/// Default factor of 1MB (1000 * 1000 bytes)
 #[derive(Debug)]
 pub struct DefaultFactorOneMegabyte;
 impl DefaultFactor for DefaultFactorOneMegabyte {
-    const FACTOR: u64 = 1024 * 1024;
+    const FACTOR: u64 = 1000 * 1000;
 }
 
-/// Default factor of 1GB (1024 * 1024 * 1024 bytes)
+/// Default factor of 1GB (1000 * 1000 * 1000 bytes)
 #[derive(Debug)]
 pub struct DefaultFactorOneGigabyte;
 impl DefaultFactor for DefaultFactorOneGigabyte {
+    const FACTOR: u64 = 1000 * 1000 * 1000;
+}
+
+/// Default factor of 1KiB (1024 bytes)
+#[derive(Debug)]
+pub struct DefaultFactorOneKibibyte;
+impl DefaultFactor for DefaultFactorOneKibibyte {
+    const FACTOR: u64 = 1024;
+}
+
+/// Default factor of 1MiB (1024 * 1024 bytes)
+#[derive(Debug)]
+pub struct DefaultFactorOneMebibyte;
+impl DefaultFactor for DefaultFactorOneMebibyte {
+    const FACTOR: u64 = 1024 * 1024;
+}
+
+/// Default factor of 1GiB (1024 * 1024 * 1024 bytes)
+#[derive(Debug)]
+pub struct DefaultFactorOneGibibyte;
+impl DefaultFactor for DefaultFactorOneGibibyte {
     const FACTOR: u64 = 1024 * 1024 * 1024;
 }
 
@@ -61,7 +82,7 @@ impl DefaultFactor for DefaultFactorOneGigabyte {
 ///
 /// // Use raw number
 /// let bytes = ByteUnit::<DefaultFactorOneMegabyte>::from(1);
-/// assert_eq!(bytes.bytes().unwrap(), 1 * 1024 * 1024);
+/// assert_eq!(bytes.bytes().unwrap(), 1 * 1000 * 1000);
 /// ```
 #[derive(Debug, Serialize, Deserialize, Eq)]
 #[serde(untagged)]
@@ -276,20 +297,38 @@ mod tests {
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024),
-            "1 with KB factor should be 1024 bytes"
+            Ok(1 * 1000),
+            "1 with KB factor should be 1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMegabyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024),
-            "1 with MB factor should be 1024*1024 bytes"
+            Ok(1 * 1000 * 1000),
+            "1 with MB factor should be 1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGigabyte> = 1.into();
         assert_eq!(
             bytes.bytes(),
+            Ok(1 * 1000 * 1000 * 1000),
+            "1 with GB factor should be 1000*1000*1000 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneKibibyte> = 1.into();
+        assert_eq!(
+            bytes.bytes(),
+            Ok(1 * 1024),
+            "1 with KiB factor should be 1024 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneMebibyte> = 1.into();
+        assert_eq!(
+            bytes.bytes(),
+            Ok(1 * 1024 * 1024),
+            "1 with MiB factor should be 1024*1024 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneGibibyte> = 1.into();
+        assert_eq!(
+            bytes.bytes(),
             Ok(1 * 1024 * 1024 * 1024),
-            "1 with GB factor should be 1024*1024*1024 bytes"
+            "1 with GiB factor should be 1024*1024*1024 bytes"
         );
 
         let bytes: ByteUnit = "1".parse().unwrap();
@@ -301,20 +340,38 @@ mod tests {
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024),
-            "String '1' with KB factor should be 1024 bytes"
+            Ok(1 * 1000),
+            "String '1' with KB factor should be 1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneMegabyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
-            Ok(1 * 1024 * 1024),
-            "String '1' with MB factor should be 1024*1024 bytes"
+            Ok(1 * 1000 * 1000),
+            "String '1' with MB factor should be 1000*1000 bytes"
         );
         let bytes: ByteUnit<DefaultFactorOneGigabyte> = "1".parse().unwrap();
         assert_eq!(
             bytes.bytes(),
+            Ok(1 * 1000 * 1000 * 1000),
+            "String '1' with GB factor should be 1000*1000*1000 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneKibibyte> = "1".parse().unwrap();
+        assert_eq!(
+            bytes.bytes(),
+            Ok(1 * 1024),
+            "String '1' with KiB factor should be 1024 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneMebibyte> = "1".parse().unwrap();
+        assert_eq!(
+            bytes.bytes(),
+            Ok(1 * 1024 * 1024),
+            "String '1' with MiB factor should be 1024*1024 bytes"
+        );
+        let bytes: ByteUnit<DefaultFactorOneGibibyte> = "1".parse().unwrap();
+        assert_eq!(
+            bytes.bytes(),
             Ok(1 * 1024 * 1024 * 1024),
-            "String '1' with GB factor should be 1024*1024*1024 bytes"
+            "String '1' with GiB factor should be 1024*1024*1024 bytes"
         );
 
         let bytes: ByteUnit<DefaultFactorOneKilobyte> = "1MiB".parse().unwrap();

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Creating a basic task:
 /// ```
-/// use crate::models::Task;
+/// use gevulot_rs::models::Task;
 ///
 /// let task = serde_json::from_str::<Task>(r#"{
 ///     "kind": "Task",
@@ -36,6 +36,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// Task with input/output contexts:
 /// ```
+/// use gevulot_rs::models::Task;
+///
 /// let task = serde_json::from_str::<Task>(r#"{
 ///     "kind": "Task",
 ///     "version": "v0",
@@ -128,7 +130,7 @@ impl From<gevulot::Task> for Task {
 ///
 /// Basic spec with just image and resources:
 /// ```
-/// use crate::models::TaskSpec;
+/// use gevulot_rs::models::TaskSpec;
 ///
 /// let spec = serde_json::from_str::<TaskSpec>(r#"{
 ///     "image": "ubuntu:latest",

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -203,10 +203,10 @@ impl From<gevulot::TaskSpec> for TaskSpec {
                 })
                 .collect(),
             resources: TaskResources {
-                cpus: (proto.cpus as i64).into(),
-                gpus: (proto.gpus as i64).into(),
-                memory: (proto.memory as i64).into(),
-                time: (proto.time as i64).into(),
+                cpus: proto.cpus.into(),
+                gpus: proto.gpus.into(),
+                memory: proto.memory.into(),
+                time: proto.time.into(),
             },
             store_stdout: proto.store_stdout,
             store_stderr: proto.store_stderr,

--- a/src/models/worker.rs
+++ b/src/models/worker.rs
@@ -129,10 +129,10 @@ impl From<gevulot::WorkerSpec> for WorkerSpec {
     fn from(proto: gevulot::WorkerSpec) -> Self {
         // Convert protobuf spec to internal spec
         WorkerSpec {
-            cpus: (proto.cpus as i64).into(),
-            gpus: (proto.gpus as i64).into(),
-            memory: (proto.memory as i64).into(),
-            disk: (proto.disk as i64).into(),
+            cpus: proto.cpus.into(),
+            gpus: proto.gpus.into(),
+            memory: proto.memory.into(),
+            disk: proto.disk.into(),
         }
     }
 }
@@ -160,10 +160,10 @@ impl From<gevulot::WorkerStatus> for WorkerStatus {
     fn from(proto: gevulot::WorkerStatus) -> Self {
         // Convert protobuf status to internal status
         WorkerStatus {
-            cpus_used: (proto.cpus_used as i64).into(),
-            gpus_used: (proto.gpus_used as i64).into(),
-            memory_used: (proto.memory_used as i64).into(),
-            disk_used: (proto.disk_used as i64).into(),
+            cpus_used: proto.cpus_used.into(),
+            gpus_used: proto.gpus_used.into(),
+            memory_used: proto.memory_used.into(),
+            disk_used: proto.disk_used.into(),
             exit_announced_at: proto.exit_announced_at as i64,
         }
     }

--- a/src/models/worker.rs
+++ b/src/models/worker.rs
@@ -19,14 +19,21 @@ use serde::{Deserialize, Serialize};
 ///
 /// Creating a basic worker:
 /// ```
-/// use crate::models::Worker;
-/// CoreUnit
+/// use gevulot_rs::models::Worker;
+///
 /// let worker = serde_json::from_str::<Worker>(r#"{
 ///     "kind": "Worker",
 ///     "version": "v0",
 ///     "metadata": {
 ///         "name": "worker-1",
-///         "tags": ["compute"]
+///         "tags": ["compute"],
+///         "description": "Worker #1",
+///         "labels": [
+///             {
+///                 "key": "my-key",
+///                 "value": "my-label"
+///             }
+///         ]
 ///     },
 ///     "spec": {
 ///         "cpus": "8 cores",
@@ -39,12 +46,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// Converting from protobuf:
 /// ```
-/// use crate::proto::gevulot::gevulot;
-/// use crate::models::Worker;
+/// use gevulot_rs::proto::gevulot::gevulot;
+/// use gevulot_rs::models::Worker;
 ///
 /// let proto_worker = gevulot::Worker {
 ///     metadata: Some(gevulot::Metadata {
 ///         name: "worker-1".to_string(),
+///         desc: "Worker #1".to_string(),
 ///         ..Default::default()
 ///     }),
 ///     spec: Some(gevulot::WorkerSpec {

--- a/src/models/workflow.rs
+++ b/src/models/workflow.rs
@@ -19,14 +19,21 @@ use serde::{Deserialize, Serialize};
 ///
 /// Creating a basic workflow:
 /// ```
-/// use crate::models::Workflow;
+/// use gevulot_rs::models::Workflow;
 ///
 /// let workflow = serde_json::from_str::<Workflow>(r#"{
 ///     "kind": "Workflow",
 ///     "version": "v0",
 ///     "metadata": {
 ///         "name": "my-workflow",
-///         "tags": ["compute"]
+///         "tags": ["compute"],
+///         "description": "Worker #1",
+///         "labels": [
+///             {
+///                 "key": "my-key",
+///                 "value": "my-label"
+///             }
+///         ]
 ///     },
 ///     "spec": {
 ///         "stages": [{
@@ -34,7 +41,9 @@ use serde::{Deserialize, Serialize};
 ///                 "image": "alpine",
 ///                 "resources": {
 ///                     "cpus": "1cpu",
-///                     "memory": "1GiB"
+///                     "memory": "1GiB",
+///                     "gpus": 0,
+///                     "time": "120s"
 ///                 }
 ///             }]
 ///         }]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -19,7 +19,7 @@
 //! - Set environment variables specified in [`env`](RuntimeConfig::env);
 //! - Set working directory to [`working_dir`](RuntimeConfig::working_dir);
 //! - Load kernel modules in order of specification in
-//! [`kernel_modules`](RuntimeConfig::kernel_modules);
+//!   [`kernel_modules`](RuntimeConfig::kernel_modules);
 //! - Run boot commands in order of specification in [`bootcmd`](RuntimeConfig::bootcmd).
 //!
 //! If current configuration defines a `command` to run, it should be updated together with its

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -234,4 +234,17 @@ impl GevulotSigner {
     pub fn address(&self) -> &AccountId {
         &self.0.public_address
     }
+
+    /// Creates a new GevulotSigner from a signing key
+    pub fn from_signing_key(signing_key: cosmrs::crypto::secp256k1::SigningKey) -> Result<Self> {
+        let public_key = signing_key.public_key();
+        let public_address = public_key.account_id("gvlt")?;
+
+        Ok(Self(Signer {
+            mnemonic: None,
+            public_address,
+            private_key: signing_key,
+            public_key,
+        }))
+    }
 }


### PR DESCRIPTION
Testing & linting is now enabled on this repo.

# Changelog

## Added

- Hex-encoded private key support (#47)
- Custom chain ID and token denomination for Gevulot client (#53)
- Conversion from Base client to Gevulot client (#55)

## Changed

- Byte/Core/Time units now exposed as `u64` instead of `i64` (#51)
- Default factors now respect SI units: kibi/mebi/gibi-bytes added, kilo/mega/giga-bytes switched to power of 10 (#57)

## Fixed

- Byte/Core/Time units exposed to public API (#51)
- `signer` module exposed to public API (#56)