### PR TITLE
Release version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gevulot-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gevulot Team"]
 description = "Gevulot Rust API"

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -50,9 +50,12 @@ pub struct BaseClient {
     pub account_sequence: Option<u64>,
 }
 
+/// Fuel policy (gas policy).
 #[derive(Debug)]
 pub enum FuelPolicy {
+    /// Fixed gas limit.
     Fixed { gas_price: f64, gas_limit: u64 },
+    /// Gas limit is calculated through tx simulation.
     Dynamic { gas_price: f64, gas_multiplier: f64 },
 }
 

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -62,8 +62,7 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `endpoint` - The endpoint URL to connect to.
-    /// * `gas_price` - The gas price to be used.
-    /// * `gas_multiplier` - The gas multiplier to be used.
+    /// * `fuel_policy` - The fuel policy to be used.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
It is a "major update" because the interface of `gevulot_rs::base_client::BaseClient` has changed.

Tagging `v0.4.0` after merging this.