### PR TITLE
Fix conversion of proto values into CoreUnit-s (for CPU and GPU)

### DIFF
--- a/proto/gevulot/gevulot/task.proto
+++ b/proto/gevulot/gevulot/task.proto
@@ -19,9 +19,13 @@ message TaskSpec {
   repeated TaskEnv env = 4;
   repeated InputContext inputContexts = 5;
   repeated OutputContext outputContexts = 6;
+  // CPU millicores required (1 core = 1000 millicores)
   uint64 cpus = 7;
+  // GPU millicores required (1 core = 1000 millicores)
   uint64 gpus = 8;
+  // Memory required in bytes
   uint64 memory = 9;
+  // Time limit in seconds
   uint64 time = 10;
   bool storeStdout = 11;
   bool storeStderr = 12;

--- a/src/models/serialization_helpers.rs
+++ b/src/models/serialization_helpers.rs
@@ -187,6 +187,18 @@ impl CoreUnit {
             }
         }
     }
+
+    /// Create from millicores value (1 core = 1000 millicores).
+    ///
+    /// If `mcores` represents an integer number of cores (evenly divisible by 1000),
+    /// then [`CoreUnit::Number`] is returned. Otherwise [`CoreUnit::String`] is returned.
+    pub fn from_millicores(mcores: u64) -> Self {
+        if mcores % 1000 == 0 {
+            Self::Number(mcores / 1000)
+        } else {
+            Self::String(mcores.to_string() + "millicores")
+        }
+    }
 }
 
 impl PartialEq for CoreUnit {
@@ -207,6 +219,7 @@ impl FromStr for CoreUnit {
 }
 
 impl From<u64> for CoreUnit {
+    /// Convert number of full cores into `CoreUnit`.
     fn from(n: u64) -> Self {
         CoreUnit::Number(n)
     }
@@ -420,6 +433,17 @@ mod tests {
 
         let cores: CoreUnit = 2.into();
         assert_eq!(cores.millicores().unwrap(), 2000);
+
+        assert_eq!(CoreUnit::from_millicores(0), CoreUnit::Number(0));
+        assert_eq!(CoreUnit::from_millicores(1000), CoreUnit::Number(1));
+        assert_eq!(
+            CoreUnit::from_millicores(1234),
+            CoreUnit::String("1234millicores".to_string())
+        );
+
+        assert_eq!(CoreUnit::from_millicores(0).millicores().unwrap(), 0);
+        assert_eq!(CoreUnit::from_millicores(1000).millicores().unwrap(), 1000);
+        assert_eq!(CoreUnit::from_millicores(1234).millicores().unwrap(), 1234);
     }
 
     #[test]

--- a/src/models/worker.rs
+++ b/src/models/worker.rs
@@ -137,8 +137,8 @@ impl From<gevulot::WorkerSpec> for WorkerSpec {
     fn from(proto: gevulot::WorkerSpec) -> Self {
         // Convert protobuf spec to internal spec
         WorkerSpec {
-            cpus: proto.cpus.into(),
-            gpus: proto.gpus.into(),
+            cpus: CoreUnit::from_millicores(proto.cpus),
+            gpus: CoreUnit::from_millicores(proto.gpus),
             memory: proto.memory.into(),
             disk: proto.disk.into(),
         }
@@ -168,8 +168,8 @@ impl From<gevulot::WorkerStatus> for WorkerStatus {
     fn from(proto: gevulot::WorkerStatus) -> Self {
         // Convert protobuf status to internal status
         WorkerStatus {
-            cpus_used: proto.cpus_used.into(),
-            gpus_used: proto.gpus_used.into(),
+            cpus_used: CoreUnit::from_millicores(proto.cpus_used),
+            gpus_used: CoreUnit::from_millicores(proto.gpus_used),
             memory_used: proto.memory_used.into(),
             disk_used: proto.disk_used.into(),
             exit_announced_at: proto.exit_announced_at as i64,


### PR DESCRIPTION
Using `CoreUnit::from(n: u64)` in that cases is not correct: proto values are in millicores and `CoreUnit::from()` converts directly into `CoreUnit::Number(n)`, which represents full cores.

Fixes #64 
